### PR TITLE
Fix call to renderCategoryListElement()

### DIFF
--- a/view/frontend/templates/sidebar.phtml
+++ b/view/frontend/templates/sidebar.phtml
@@ -42,7 +42,7 @@ function renderCategoryChildren($block, $category, $maxLevel, $level = 0)
 
     $html = '<ul class="o-list o-list--unstyled">';
     foreach ($childCategories as $childCategory) {
-        $html .= renderCategoryListElement($block, $childCategory, $level);
+        $html .= renderCategoryListElement($block, $childCategory, $maxLevel, $level);
     }
     $html .= '</ul>';
 


### PR DESCRIPTION
$level was passed as the third parameter, but it should have been the forth. The result was that the CSS class of every level was set as `level0` instead of the actual level.